### PR TITLE
Refactor the engine to make machine learning work easier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apologies"
-version = "0.1.10"
+version = "0.1.11"
 description = "Python code to play a game similar to Sorry"
 authors = ["Kenneth J. Pronovici <pronovic@ieee.org>"]
 license = "Apache-2.0"

--- a/src/apologies/engine.py
+++ b/src/apologies/engine.py
@@ -103,6 +103,11 @@ class Engine:
             return "Game waiting to start"
 
     @property
+    def game(self) -> Game:
+        """A reference to the underlying game."""
+        return self._game
+
+    @property
     def started(self) -> bool:
         """Whether the game is started."""
         return self._game.started

--- a/src/apologies/engine.py
+++ b/src/apologies/engine.py
@@ -112,6 +112,11 @@ class Engine:
         """Whether the game is completed."""
         return self._game.completed
 
+    def reset(self) -> Game:
+        """Reset game state."""
+        self._game = self._default_game()
+        return self._game
+
     def start_game(self) -> Game:
         """
         Start the game, returning game state.

--- a/src/apologies/engine.py
+++ b/src/apologies/engine.py
@@ -152,10 +152,10 @@ class Engine:
             while not done:
                 view = self._game.create_player_view(color)
                 if self.mode == GameMode.ADULT:
-                    move = self._choose_next_move(character, player, view)
+                    move = self.choose_next_move(character, view)
                     done = self._play_next_adult(player, move)
                 else:
-                    move = self._choose_next_move(character, player, view)
+                    move = self.choose_next_move(character, view)
                     done = self._play_next_standard(player, move)
 
             return self._game
@@ -167,12 +167,12 @@ class Engine:
         """Construct the legal moves based on a player view."""
         return self._rules.construct_legal_moves(view, card=None if self.mode == GameMode.ADULT else self._game.deck.draw())
 
-    def _choose_next_move(self, character: Character, player: Player, view: PlayerView) -> Move:
-        """Choose the next move for a player."""
+    def choose_next_move(self, character: Character, view: PlayerView) -> Move:
+        """Choose the next move for a character based on a player view."""
         legal_moves = self.construct_legal_moves(view)
         move = character.choose_move(self.mode, view, legal_moves[:], Rules.evaluate_move)
         if move not in legal_moves:  # an illegal move is ignored and we choose randomly for the character
-            self._game.track("Illegal move: a random legal move will be chosen", player)
+            self._game.track("Illegal move: a random legal move will be chosen", view.player)
             move = random.choice(legal_moves)
         return move
 

--- a/src/apologies/rules.py
+++ b/src/apologies/rules.py
@@ -5,6 +5,7 @@
 Implements rules related to game play.
 """
 
+import uuid
 from enum import Enum
 from typing import List, Optional
 
@@ -69,11 +70,17 @@ class Move:
         card(Card): The card that is being played by this move
         actions(List[Action]): List of actions to execute
         side_effects(List[Action]): List of side effects that occurred as a result of the actions
+        id(str): Identifier for this move, which must be unique among all legal moves this move is grouped with
     """
 
     card = attr.ib(type=Card)
     actions = attr.ib(type=List[Action])
     side_effects = attr.ib(type=List[Action])
+    id = attr.ib(type=str)
+
+    @id.default
+    def _default_id(self) -> str:
+        return uuid.uuid4().hex
 
     @side_effects.default
     def _default_side_effects(self) -> List[Action]:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -76,6 +76,12 @@ class TestEngine:
             assert engine.completed is True
             assert engine.state == "Game completed"
 
+    def test_reset(self):
+        engine = TestEngine._create_engine()
+        saved = engine._game
+        engine.reset()
+        assert engine._game is not None and engine._game is not saved and not engine._game.started
+
     def test_start_game(self):
         engine = TestEngine._create_engine()
         engine._rules.start_game = MagicMock()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -51,6 +51,7 @@ class TestEngine:
         assert engine.started is False
         assert engine.completed is False
         assert engine.state == "Game waiting to start"
+        assert engine.game is engine._game
         assert len(engine._game.players) == 2
         assert engine._queue.entries == [PlayerColor.RED, PlayerColor.YELLOW]
         assert engine._rules.mode == GameMode.STANDARD

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -113,7 +113,7 @@ class TestRules:
         card_pawn1_moves = []
         card_pawn2_moves = []
         legal_moves = [card_pawn1_moves, card_pawn2_moves]
-        expected_moves = [Move(card, [], id="uuid")]  # result is a forfeit for the only card
+        expected_moves = [Move(card, [])]  # result is a forfeit for the only card
 
         view = MagicMock()
         view.player = MagicMock(color=PlayerColor.RED, hand=hand, pawns=player_pawns)
@@ -146,7 +146,7 @@ class TestRules:
         hand2_pawn1_moves = []
         hand2_pawn2_moves = []
         legal_moves = [hand1_pawn1_moves, hand1_pawn2_moves, hand2_pawn1_moves, hand2_pawn2_moves]
-        expected_moves = [Move(hand1, [], id="uuid"), Move(hand2, [], id="uuid")]  # result is a forfeit for all cards in the hand
+        expected_moves = [Move(hand1, []), Move(hand2, [])]  # result is a forfeit for all cards in the hand
 
         view = MagicMock()
         view.player = MagicMock(color=PlayerColor.RED, hand=hand, pawns=player_pawns)
@@ -180,16 +180,14 @@ class TestRules:
         all_pawns = [MagicMock(), MagicMock()]
 
         card_pawn1_moves = [
-            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
-            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
+            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)]),
+            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)]),
         ]
-        card_pawn2_moves = [
-            Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)], id="uuid")
-        ]
+        card_pawn2_moves = [Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)])]
         legal_moves = [card_pawn1_moves, card_pawn2_moves]
         expected_moves = [
-            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
-            Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)], id="uuid"),
+            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)]),
+            Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)]),
         ]  # result is a list of all returned moves, with duplicates are removed
 
         view = MagicMock()
@@ -219,20 +217,18 @@ class TestRules:
         all_pawns = [MagicMock(), MagicMock()]
 
         hand1_pawn1_moves = [
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)]),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)]),
         ]
-        hand1_pawn2_moves = [
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)], id="uuid")
-        ]
-        hand2_pawn1_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())], id="uuid")]
-        hand2_pawn2_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())], id="uuid")]
+        hand1_pawn2_moves = [Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)])]
+        hand2_pawn1_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())])]
+        hand2_pawn2_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())])]
         legal_moves = [hand1_pawn1_moves, hand1_pawn2_moves, hand2_pawn1_moves, hand2_pawn2_moves]
         expected_moves = [
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)], id="uuid"),
-            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())], id="uuid"),
-            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())], id="uuid"),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)]),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)]),
+            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())]),
+            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())]),
         ]  # result is a list of all returned moves, with duplicates are removed
 
         view = MagicMock()

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2,12 +2,14 @@
 # vim: set ft=python ts=4 sw=4 expandtab:
 # pylint: disable=no-self-use,protected-access,too-many-locals,too-many-statements
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from apologies.game import ADULT_HAND, DECK_SIZE, PAWNS, Card, CardType, Game, GameMode, Pawn, PlayerColor, Position
 from apologies.rules import Action, ActionType, BoardRules, Move, Rules
+
+_UUID = MagicMock(return_value=MagicMock(hex="uuid"))  # any call to get a random UUID returns a UUID with hex value "uuid"
 
 
 class TestAction:
@@ -21,12 +23,22 @@ class TestAction:
 
 
 class TestMove:
-    def test_constructor(self):
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
+    def test_constructor_uuid(self):
         card = Card(3, CardType.CARD_12)
         actions = [Action(ActionType.MOVE_TO_START, pawn=Pawn(PlayerColor.BLUE, 1, "whatever"))]
         move = Move(card, actions)
         assert move.card is card
         assert move.actions == actions
+        assert move.id == "uuid"
+
+    def test_constructor_explicit(self):
+        card = Card(3, CardType.CARD_12)
+        actions = [Action(ActionType.MOVE_TO_START, pawn=Pawn(PlayerColor.BLUE, 1, "whatever"))]
+        move = Move(card, actions, id="whatever")
+        assert move.card is card
+        assert move.actions == actions
+        assert move.id == "whatever"
 
 
 class TestRules:
@@ -84,6 +96,7 @@ class TestRules:
         assert game.players[PlayerColor.BLUE].pawns[0].position.square == 19
         assert len(game.players[PlayerColor.BLUE].hand) == ADULT_HAND
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_no_moves_with_card(self):
         card = MagicMock()
 
@@ -100,7 +113,7 @@ class TestRules:
         card_pawn1_moves = []
         card_pawn2_moves = []
         legal_moves = [card_pawn1_moves, card_pawn2_moves]
-        expected_moves = [Move(card, [])]  # result is a forfeit for the only card
+        expected_moves = [Move(card, [], id="uuid")]  # result is a forfeit for the only card
 
         view = MagicMock()
         view.player = MagicMock(color=PlayerColor.RED, hand=hand, pawns=player_pawns)
@@ -114,6 +127,7 @@ class TestRules:
             [call(PlayerColor.RED, card, pawn1, all_pawns), call(PlayerColor.RED, card, pawn2, all_pawns)]
         )
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_no_moves_no_card(self):
         card = None
 
@@ -132,7 +146,7 @@ class TestRules:
         hand2_pawn1_moves = []
         hand2_pawn2_moves = []
         legal_moves = [hand1_pawn1_moves, hand1_pawn2_moves, hand2_pawn1_moves, hand2_pawn2_moves]
-        expected_moves = [Move(hand1, []), Move(hand2, [])]  # result is a forfeit for all cards in the hand
+        expected_moves = [Move(hand1, [], id="uuid"), Move(hand2, [], id="uuid")]  # result is a forfeit for all cards in the hand
 
         view = MagicMock()
         view.player = MagicMock(color=PlayerColor.RED, hand=hand, pawns=player_pawns)
@@ -151,6 +165,7 @@ class TestRules:
             ]
         )
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_with_moves_with_card(self):
         card = MagicMock()
 
@@ -165,14 +180,16 @@ class TestRules:
         all_pawns = [MagicMock(), MagicMock()]
 
         card_pawn1_moves = [
-            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)]),
-            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)]),
+            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
+            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
         ]
-        card_pawn2_moves = [Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)])]
+        card_pawn2_moves = [
+            Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)], id="uuid")
+        ]
         legal_moves = [card_pawn1_moves, card_pawn2_moves]
         expected_moves = [
-            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)]),
-            Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)]),
+            Move(card, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
+            Move(card, [Action(ActionType.MOVE_TO_POSITION, pawn2), Action(ActionType.MOVE_TO_START, pawn2)], id="uuid"),
         ]  # result is a list of all returned moves, with duplicates are removed
 
         view = MagicMock()
@@ -187,6 +204,7 @@ class TestRules:
             [call(PlayerColor.RED, card, pawn1, all_pawns), call(PlayerColor.RED, card, pawn2, all_pawns)]
         )
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_with_moves_no_card(self):
         card = None
 
@@ -201,18 +219,20 @@ class TestRules:
         all_pawns = [MagicMock(), MagicMock()]
 
         hand1_pawn1_moves = [
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)]),
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)]),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
         ]
-        hand1_pawn2_moves = [Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)])]
-        hand2_pawn1_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())])]
-        hand2_pawn2_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())])]
+        hand1_pawn2_moves = [
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)], id="uuid")
+        ]
+        hand2_pawn1_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())], id="uuid")]
+        hand2_pawn2_moves = [Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())], id="uuid")]
         legal_moves = [hand1_pawn1_moves, hand1_pawn2_moves, hand2_pawn1_moves, hand2_pawn2_moves]
         expected_moves = [
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)]),
-            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)]),
-            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())]),
-            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())]),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn1)], id="uuid"),
+            Move(hand1, [Action(ActionType.MOVE_TO_START, pawn2), Action(ActionType.MOVE_TO_POSITION, pawn2)], id="uuid"),
+            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn1, Position())], id="uuid"),
+            Move(hand2, [Action(ActionType.MOVE_TO_POSITION, pawn2, Position())], id="uuid"),
         ]  # result is a list of all returned moves, with duplicates are removed
 
         view = MagicMock()
@@ -498,6 +518,7 @@ def _legal_moves(color, game, index, cardtype):
 
 
 class TestLegalMoves:
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_1(self):
         # No legal moves if no pawn in start, on the board, or in safe
         game = _setup_game()
@@ -544,6 +565,7 @@ class TestLegalMoves:
         card, pawn, view, moves = _legal_moves(RED, game, 0, "1")
         assert moves == [Move(card, actions=[_square(pawn, 7)], side_effects=[_bump(view, GREEN, 1)])]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_2(self):
         # No legal moves if no pawn in start, on the board, or in safe
         game = _setup_game()
@@ -590,6 +612,7 @@ class TestLegalMoves:
         card, pawn, view, moves = _legal_moves(RED, game, 0, "2")
         assert moves == [Move(card, actions=[_square(pawn, 8)], side_effects=[_bump(view, GREEN, 1)])]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_3(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -617,6 +640,7 @@ class TestLegalMoves:
         card, pawn, view, moves = _legal_moves(RED, game, 0, "3")
         assert moves == [Move(card, actions=[_square(pawn, 9)], side_effects=[_bump(view, GREEN, 1)])]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_4(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -644,6 +668,7 @@ class TestLegalMoves:
         card, pawn, view, moves = _legal_moves(RED, game, 0, "4")
         assert moves == [Move(card, actions=[_square(pawn, 2)], side_effects=[_bump(view, GREEN, 1)])]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_5(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -671,6 +696,7 @@ class TestLegalMoves:
         card, pawn, view, moves = _legal_moves(RED, game, 0, "5")
         assert moves == [Move(card, actions=[_square(pawn, 11)], side_effects=[_bump(view, GREEN, 1)])]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_7(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -742,6 +768,7 @@ class TestLegalMoves:
             Move(card, actions=[_square(pawn, 12), _square(other2, 56)], side_effects=[]),  # split (6, 1)
         ]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_8(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -769,6 +796,7 @@ class TestLegalMoves:
         card, pawn, view, moves = _legal_moves(RED, game, 0, "8")
         assert moves == [Move(card, actions=[_square(pawn, 14)], side_effects=[_bump(view, GREEN, 1)])]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_10(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -821,6 +849,7 @@ class TestLegalMoves:
             Move(card, actions=[_square(pawn, 4)], side_effects=[_bump(view, GREEN, 1)]),
         ]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_11(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -866,6 +895,7 @@ class TestLegalMoves:
             Move(card, actions=[_square(pawn, 26)], side_effects=[]),
         ]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_12(self):
         # No legal moves if no pawn on the board, or in safe
         game = _setup_game()
@@ -893,6 +923,7 @@ class TestLegalMoves:
         card, pawn, view, moves = _legal_moves(RED, game, 0, "12")
         assert moves == [Move(card, actions=[_square(pawn, 18)], side_effects=[_bump(view, GREEN, 1)])]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_card_apologies(self):
         # No legal moves if no pawn in start
         game = _setup_game()
@@ -914,6 +945,7 @@ class TestLegalMoves:
             Move(card, actions=[_square(pawn, 19), _bump(view, BLUE, 1)], side_effects=[]),
         ]
 
+    @patch("apologies.rules.uuid.uuid4", new=_UUID)
     def test_construct_legal_moves_special(self):
         # Move pawn into safe zone
         game = _setup_game()


### PR DESCRIPTION
This PR refactors the Engine interface to make it easier to use in other contexts.  The existing public interface is preserved, but additional public properties and methods are exposed, so that the machine-learning code in [apologies-ml](https://github.com/pronovic/apologies-ml) can operate the way it needs to without having to mess with private implementation details of the engine.  Each refactoring step is in an individual commit.  The changes are substantial, but since the unit tests didn't really change, we can be confident that nothing is broken.

The PR also adds an id on the Move class.  This change also makes things easier for machine-learning code.  This way, you can look up a move by id without having to do any other equality-matching or any other complicated code.