### PR TITLE
Regenerate doc/requirements.txt with Poetry v1.1.3 to fix GitHub pipeline

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Install Dependencies
         run: poetry install -v
         if: steps.cache.outputs.cache-hit != 'true'
-#      - name: Run Tox test suite
-#        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"
+      - name: Run Tox test suite
+        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Install Dependencies
         run: poetry install -v
         if: steps.cache.outputs.cache-hit != 'true'
-      - name: Run Tox test suite
-        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"
+#      - name: Run Tox test suite
+#        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"

--- a/.toxrc
+++ b/.toxrc
@@ -16,4 +16,4 @@ commands =
 [testenv:precommit]
 whitelist_externals = poetry
 commands =
-   poetry run pre-commit run --all-files
+   poetry run pre-commit run --all-files --show-diff-on-failure

--- a/.toxrc
+++ b/.toxrc
@@ -16,4 +16,6 @@ commands =
 [testenv:precommit]
 whitelist_externals = poetry
 commands =
+   poetry --version
+   poetry version
    poetry run pre-commit run --all-files --show-diff-on-failure

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,67 +1,67 @@
 alabaster==0.7.12
 appdirs==1.4.4
-astroid==2.4.2
-atomicwrites==1.4.0; sys_platform == "win32"
-attrs==19.3.0
-babel==2.8.0
-black==19.10b0
+astroid==2.4.2; python_version >= "3.5"
+atomicwrites==1.4.0; python_version >= "2.7" and python_full_version < "3.0.0" and sys_platform == "win32" or python_full_version >= "3.4.0" and sys_platform == "win32"
+attrs==19.3.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+babel==2.8.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+black==19.10b0; python_version >= "3.6"
 cattrs==1.0.0
 certifi==2020.6.20
-cfgv==3.2.0
+cfgv==3.2.0; python_full_version >= "3.6.1"
 chardet==3.0.4
-click==7.1.2
-colorama==0.4.4; sys_platform == "win32" or platform_system == "Windows"
-coverage==5.3
+click==7.1.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+colorama==0.4.4; python_version >= "2.7" and python_full_version < "3.0.0" and sys_platform == "win32" or python_version >= "2.7" and python_full_version < "3.0.0" and sys_platform == "win32" and platform_system == "Windows" or sys_platform == "win32" and python_full_version >= "3.5.0" or sys_platform == "win32" and python_full_version >= "3.5.0" and platform_system == "Windows" or python_version >= "2.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_full_version >= "3.5.0"
+coverage==5.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
 distlib==0.3.1
-docutils==0.16
+docutils==0.16; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 filelock==3.0.12
-identify==1.5.6
-idna==2.10
-imagesize==1.2.0
-importlib-metadata==2.0.0; python_version < "3.8"
-isort==4.3.21
-jinja2==2.11.2
-lazy-object-proxy==1.4.3; python_version >= "3"
-markupsafe==1.1.1
+identify==1.5.6; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+idna==2.10; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+imagesize==1.2.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+importlib-metadata==2.0.0; python_version >= "2.7" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8"
+isort==4.3.21; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+jinja2==2.11.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+lazy-object-proxy==1.4.3; python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3"
+markupsafe==1.1.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 mccabe==0.6.1
-more-itertools==8.5.0
-mypy==0.770
+more-itertools==8.5.0; python_version >= "3.5"
 mypy-extensions==0.4.3
+mypy==0.770; python_version >= "3.5"
 nodeenv==1.5.0
-orjson==2.6.8
-packaging==20.4
-pathspec==0.8.0
-pendulum==2.1.2
-pluggy==0.13.1
-pre-commit==2.7.1
-py==1.9.0
-pygments==2.7.1
-pylint==2.6.0
-pyparsing==2.4.7
-pytest==5.4.3
-python-dateutil==2.8.1
+orjson==2.6.8; python_version >= "3.6"
+packaging==20.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+pathspec==0.8.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+pendulum==2.1.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+pluggy==0.13.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+pre-commit==2.7.1; python_full_version >= "3.6.1"
+py==1.9.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+pygments==2.7.1; python_version >= "3.5"
+pylint==2.6.0; python_version >= "3.5"
+pyparsing==2.4.7; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
+pytest==5.4.3; python_version >= "3.5"
+python-dateutil==2.8.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 pytz==2020.1
-pytzdata==2020.1
-pyyaml==5.3.1
+pytzdata==2020.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+pyyaml==5.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 regex==2020.10.15
-requests==2.24.0
-six==1.15.0
+requests==2.24.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
+six==1.15.0; python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3"
 snowballstemmer==2.0.0
-sphinx==2.4.4
-sphinx-autoapi==1.5.1
-sphinxcontrib-applehelp==1.0.2
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==1.0.3
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.4
+sphinx-autoapi==1.5.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+sphinx==2.4.4; python_version >= "3.5"
+sphinxcontrib-applehelp==1.0.2; python_version >= "3.5"
+sphinxcontrib-devhelp==1.0.2; python_version >= "3.5"
+sphinxcontrib-htmlhelp==1.0.3; python_version >= "3.5"
+sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
+sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
+sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 toml==0.10.1
-tox==3.20.1
-typed-ast==1.4.1
+tox==3.20.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+typed-ast==1.4.1; python_version < "3.8" and python_version >= "3"
 typing-extensions==3.7.4.3
-unidecode==1.1.1
-urllib3==1.25.10
-virtualenv==20.0.35
+unidecode==1.1.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+urllib3==1.25.10; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
+virtualenv==20.0.35; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 wcwidth==0.2.5
 wrapt==1.12.1; python_version >= "3"
-zipp==3.3.0; python_version < "3.8"
+zipp==3.3.0; python_version < "3.8" and python_version >= "3.6"

--- a/run
+++ b/run
@@ -13,6 +13,11 @@ run_activate() {
    echo "source "$(dirname $(poetry run which python) 2>/dev/null)/activate""
 }
 
+# Regenerate the doc/requirements file"
+run_requirements() {
+   poetry export --format=requirements.txt --without-hashes --dev --output=docs/requirements.txt
+}
+
 # Run the Pylint code checker
 run_pylint() {
    poetry run which pylint > /dev/null
@@ -189,6 +194,9 @@ case $1 in
    activate)
       run_activate
       ;;
+   requirements)
+      run_requirements
+      ;;
    *lint)
       run_pylint
       ;;
@@ -242,6 +250,7 @@ case $1 in
       echo ""
       echo "- run install: Setup the virtualenv via Poetry and install pre-commit hooks"
       echo "- run activate: Print command needed to activate the Poetry virtualenv"
+      echo "- run requirements: Regenerate the doc/requirements file"
       echo "- run checks: Run the PyLint and MyPy code checkers"
       echo "- run format: Run the Black code formatter"
       echo "- run test: Run the unit tests"

--- a/run
+++ b/run
@@ -13,7 +13,7 @@ run_activate() {
    echo "source "$(dirname $(poetry run which python) 2>/dev/null)/activate""
 }
 
-# Regenerate the doc/requirements file"
+# Regenerate the docs/requirements.txt file"
 run_requirements() {
    poetry export --format=requirements.txt --without-hashes --dev --output=docs/requirements.txt
 }
@@ -250,7 +250,7 @@ case $1 in
       echo ""
       echo "- run install: Setup the virtualenv via Poetry and install pre-commit hooks"
       echo "- run activate: Print command needed to activate the Poetry virtualenv"
-      echo "- run requirements: Regenerate the doc/requirements file"
+      echo "- run requirements: Regenerate the docs/requirements.txt file"
       echo "- run checks: Run the PyLint and MyPy code checkers"
       echo "- run format: Run the Black code formatter"
       echo "- run test: Run the unit tests"


### PR DESCRIPTION
The GitHub pipeline has started failing at the pre-commit hook check step.  The generated `doc/requirements.txt` file differs from the checked-in version.  I traced this to a change in Poetry.  The latest Poetry (v1.1.3 as of this writing) generates a different format file (containing extra metadata) vs. the one I had installed locally (v1.0.5).   I fixed the pipeline by regenerating the checked-in `requirements.txt` with the latest version of Poetry.  At the same time, I tweaked the pipeline itself to dump some useful information that will help if this happens again.  I also added a `run requirements` script to make it easier to manually regenerate the requirements file.