### PR TITLE
Prepare for Python 3.9 (not compatible yet)

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,6 +2,16 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="DuplicatedCode" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="3.7" />
+            <item index="1" class="java.lang.String" itemvalue="3.8" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
     <inspection_tool class="PyPep8Inspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyTypeHintsInspection" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -65,9 +65,30 @@ $ brew install python3
 $ brew install poetry
 ```
 
-When you're done, make sure that the `python` on your `$PATH` is Python 3 from
-Homebrew (in `/usr/local`).  By default, you'll get the standard Python 2 that
-comes with MacOS.
+When you're done, you probably want to set up your profile so the `python` on
+your `$PATH` is Python 3 from Homebrew (in `/usr/local`).  By default, you'll
+get the standard Python 2 that comes with MacOS.
+
+At this point, you can either let Poetry use its defaults, or tell it explicity
+which Python interpreter you want it to use.  Poetry seems to be quite
+aggressive about using the most recent version of Python available, which might
+not be what you want.
+
+For instance, as of this writing, the Homebrew default Python is 3.8, but if
+you also have 3.9 installed (even if it's not on the `$PATH`) Poetry will use
+it.  To force Poetry to use a particular version, run:
+
+```
+$ poetry env use 3.8
+```
+
+You can check the version that is in use with:
+
+```
+$ poetry env info
+```
+
+If you're still having problems, see [this discussion](https://github.com/python-poetry/poetry/issues/522) and also [Poetry PR #731](https://github.com/python-poetry/poetry/pull/731).
 
 ### Debian
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -69,27 +69,6 @@ When you're done, you probably want to set up your profile so the `python` on
 your `$PATH` is Python 3 from Homebrew (in `/usr/local`).  By default, you'll
 get the standard Python 2 that comes with MacOS.
 
-At this point, you can either let Poetry use its defaults, or tell it explicity
-which Python interpreter you want it to use.  Poetry seems to be quite
-aggressive about using the most recent version of Python available, which might
-not be what you want.
-
-For instance, as of this writing, the Homebrew default Python is 3.8, but if
-you also have 3.9 installed (even if it's not on the `$PATH`) Poetry will use
-it.  To force Poetry to use a particular version, run:
-
-```
-$ poetry env use 3.8
-```
-
-You can check the version that is in use with:
-
-```
-$ poetry env info
-```
-
-If you're still having problems, see [this discussion](https://github.com/python-poetry/poetry/issues/522) and also [Poetry PR #731](https://github.com/python-poetry/poetry/pull/731).
-
 ### Debian
 
 First, install Python 3 and related tools:
@@ -108,6 +87,46 @@ Then, install Poetry in your home directory:
 ```
 $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 ```
+
+## Configure Poetry's Python Interpreter
+
+At this point, you can either let Poetry use its defaults, or tell it explicity
+which Python interpreter you want it to use.  On MacOS anyway, Poetry >= v1.1.3
+seems to be quite aggressive about using the most recent version of Python
+available on my system (even if it's not on my `$PATH`), which is not always
+what I want.
+
+To force Poetry to use a particular version of Python on the `$PATH`, do this:
+
+```
+$ poetry env use 3.8
+```
+
+To force Poetry to use a version that isn't on the `$PATH`, you can't just use
+the version number as shown above.  You have to provide the whole path:
+
+```
+$ poetry env use /usr/local/Cellar/python@3.9/3.9.0/bin/python3.9
+```
+
+You can check the version that is in use with:
+
+```
+$ poetry env info
+```
+
+If you switch between versions, it is a good idea to sanity check what is
+actually being used.  I've noticed that if I start on 3.8 and then switch to
+3.9 (in the order shown above), then `python env info` still reports Python
+3.8.6 when I'm done.  The fix seems to be to remove the virutalenvs and start
+over:
+
+```
+$ poetry env list
+$ poetry env remove <item>
+```
+
+For more background, see [this discussion](https://github.com/python-poetry/poetry/issues/522) and also [Poetry PR #731](https://github.com/python-poetry/poetry/pull/731).
 
 ## Activating the Virtual Environment
 
@@ -134,6 +153,7 @@ Usage: run <command>
 
 - run install: Setup the virtualenv via Poetry and install pre-commit hooks
 - run activate: Print command needed to activate the Poetry virtualenv
+- run requirements: Regenerate the docs/requirements.txt file
 - run checks: Run the PyLint and MyPy code checkers
 - run format: Run the Black code formatter
 - run test: Run the unit tests

--- a/poetry.lock
+++ b/poetry.lock
@@ -743,8 +743,8 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "7d367ec24616940c9c3565d8db0e35545f172bbd05f2135e86d48843115eb8b2"
+python-versions = ">=3.7,<=3.9"
+content-hash = "89fe39e22038369468a80f70cdc5e43df4b36a0ca938b6bf8183a481c8533108"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers=[
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7,<=3.9"
 attrs = "^19.3.0"
 cattrs = "^1.0.0"
 pendulum = "^2.1.0"


### PR DESCRIPTION
I tested with Python 3.9.0 (which was released today), and determined that it doesn't yet work with this codebase.  In particular, the cattrs library is not compatible.  See [issue #100](https://github.com/Tinche/cattrs/issues/100).  According to the release notes, v1.1.0 (due to be released "soon"), does support Python 3.9.  Once that's available, we can fully convert.  This PR clarifies the dependencies.