### PR TITLE
update build-system to use poetry.core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ sphinx = "^2.4.4"
 toml = "^0.10.0"
 pre-commit = "^2.2.0"
 black = "^19.10b0"
-mypy = "^0.790"   
+mypy = "^0.790"
 isort = "^4.3.21"
 sphinx-autoapi = "^1.2.1"
 
@@ -55,5 +55,5 @@ exclude = '''
 '''
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Update the `pyproject.toml` build section to be consistent with the newest recommendation from the poetry docs 
[here](https://python-poetry.org/docs/pyproject/#poetry-and-pep-517): 

"If your pyproject.toml file still references poetry directly as a build backend, you should update it to reference poetry_core instead."