### PR TITLE
Improvements to Read the Docs integration

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,4 +37,4 @@ jobs:
         run: poetry install -v
         if: steps.cached-poetry.outputs.cache-hit != 'true'
       - name: Run Tox test suite
-        run: poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"

--- a/.toxrc
+++ b/.toxrc
@@ -2,7 +2,6 @@
 isolated_build = true
 envlist = 
    precommit,
-   docs,
    {py}-{coverage,nocoverage}
 ignore_basepython_conflict = true
 
@@ -20,11 +19,3 @@ commands =
    poetry --version
    poetry version
    poetry run pre-commit run --all-files --show-diff-on-failure
-
-[testenv:docs]
-whitelist_externals = poetry
-changedir = docs
-commands =
-   poetry --version
-   poetry version
-   poetry run sphinx-build -b html -d _build/doctrees . _build/html

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -490,7 +490,7 @@ $ run demo --players=3 --mode=ADULT --delay=0.1
 
 ### Documentation
 
-Documentation at [Read the Docs](https://apologies.readthedocs.io/en/latest/)
+Documentation at [Read the Docs](https://apologies.readthedocs.io/en/stable/)
 is generated via a GitHub hook each time code is pushed to master.  So, there
 is no formal release process for the documentation.
 

--- a/PyPI.md
+++ b/PyPI.md
@@ -4,9 +4,9 @@
 ![](https://img.shields.io/pypi/wheel/apologies.svg)
 ![](https://img.shields.io/pypi/pyversions/apologies.svg)
 ![](https://github.com/pronovic/apologies/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/apologies/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/apologies/badge/?version=stable&style=flat)
 
-[Apologies](https://github.com/pronovic/apologies) is a Python library that implements a game similar to the [Sorry](https://en.wikipedia.org/wiki/Sorry!_(game)) board game.  On UNIX-like platforms, it includes a console demo that plays the game with automated players, intended for use by developers and not by end users.  See the [documentation](https://apologies.readthedocs.io/en/latest) for notes about the public interface.
+[Apologies](https://github.com/pronovic/apologies) is a Python library that implements a game similar to the [Sorry](https://en.wikipedia.org/wiki/Sorry!_(game)) board game.  On UNIX-like platforms, it includes a console demo that plays the game with automated players, intended for use by developers and not by end users.  See the [documentation](https://apologies.readthedocs.io/en/stable) for notes about the public interface.
 
 It was written as a learning exercise and technology demonstration effort, and
 serves as a complete example of how to manage a modern (circa 2020) Python

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 ![](https://img.shields.io/pypi/wheel/apologies.svg)
 ![](https://img.shields.io/pypi/pyversions/apologies.svg)
 ![](https://github.com/pronovic/apologies/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/apologies/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/apologies/badge/?version=stable&style=flat)
 
 This is a Python library that implements a game similar to the [Sorry](https://en.wikipedia.org/wiki/Sorry!_(game)) board game.  On UNIX-like platforms, it includes a console demo that plays the game with automated players, intended for use by developers and not by end users.
 
-It was written as a learning exercise and technology demonstration effort, and serves as a complete example of how to manage a modern (circa 2020) Python project, including style checks, code formatting, integration with IntelliJ, [CI builds at GitHub](https://github.com/pronovic/apologies/actions), and integration with [PyPI](https://pypi.org/project/apologies/) and [Read the Docs](https://apologies.readthedocs.io/en/latest/).
+It was written as a learning exercise and technology demonstration effort, and serves as a complete example of how to manage a modern (circa 2020) Python project, including style checks, code formatting, integration with IntelliJ, [CI builds at GitHub](https://github.com/pronovic/apologies/actions), and integration with [PyPI](https://pypi.org/project/apologies/) and [Read the Docs](https://apologies.readthedocs.io/en/stable/).
 
 Developer documentation is found in [DEVELOPER.md](DEVELOPER.md).  See that file for notes about how the code is structured, how to set up a development environment, etc.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,8 +15,8 @@ Release v\ |version|
 .. image:: https://github.com/pronovic/apologies/workflows/Test%20Suite/badge.svg
     :target: https://github.com/pronovic/apologies
 
-.. image:: https://readthedocs.org/projects/apologies/badge/?version=latest&style=flat
-    :target: https://apologies.readthedocs.io/en/latest/
+.. image:: https://readthedocs.org/projects/apologies/badge/?version=stable&style=flat
+    :target: https://apologies.readthedocs.io/en/stable/
 
 Apologies_ is a Python library that implements a game similar to the Sorry_
 board game.  On UNIX-like platforms, it includes a console demo that plays the

--- a/run
+++ b/run
@@ -112,7 +112,7 @@ run_tox() {
       run_install
    fi
 
-   poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+   poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"
 }
 
 # Build the Sphinx documentation for apologies.readthedocs.io


### PR DESCRIPTION
Read the Docs now offers a config option to build pull requests.  The generated documentation is removed 90 days after the branch is deleted.   Since I've run into cases where the docs built correctly in the Tox test suite but failed at Read the Docs itself, it seems better to rely on the official Read the Docs build as the merge gate.

At the same time, I adjusted configuration to properly use the stable branch at Read the Docs (which always points at the most recent tagged release), so I converted all of the links to use that URL.