### PR TITLE
Upgrade virtualenv embedded tools

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Upgrade pip
-        run: pip install --upgrade pip
-      - name: Check pip
-        run: pip --version
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.1 # see https://github.com/snok/install-poetry
         with:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check pip
         run: poetry run pip --version
       - name: Upgrade pip
-        run: poetry run pip --upgrade pip
+        run: poetry run pip install --upgrade pip
       - name: Check pip
         run: poetry run pip --version
       #- name: Run Tox test suite

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Upgrade pip
+        run: pip install --upgrade pip
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1.1.1 # see https://github.com/snok/install-poetry
         with:
@@ -29,12 +31,6 @@ jobs:
           virtualenvs-in-project: true
       - name: Install Dependencies
         run: poetry install -v
-      - name: Upgrade embedded wheels in the virtualenv
-        # This is the recommended way to upgrade things like pip within the
-        # virtualenv.  If there is a vulnerability in pip, then Safety will
-        # alert on it, which is why it's important for these to be up-to-date.
-        # See: https://github.com/python-poetry/poetry/issues/1651#issuecomment-746486601
-        run: poetry run virtualenv --upgrade-embed-wheels
       - name: Run Tox test suite
         run: poetry run tox -c .toxrc -e "checks,coverage"
       - name: Upload coverage data to coveralls.io

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,6 +37,10 @@ jobs:
         run: poetry install -v
       - name: Check pip
         run: poetry run pip --version
+      - name: Upgrade pip
+        run: poetry run pip --upgrade pip
+      - name: Check pip
+        run: poetry run pip --version
       #- name: Run Tox test suite
         #run: poetry run tox -c .toxrc -e "checks,coverage"
       #- name: Upload coverage data to coveralls.io

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,10 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python: [3.7]
-        #os: [ubuntu-latest, macos-latest, windows-latest]
-        #python: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: [3.7, 3.8, 3.9]
     steps: 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,13 +28,15 @@ jobs:
         run: pip install --upgrade pip
       - name: Check pip
         run: pip --version
-      #- name: Install and configure Poetry
-        #uses: snok/install-poetry@v1.1.1 # see https://github.com/snok/install-poetry
-        #with:
-          #virtualenvs-create: true
-          #virtualenvs-in-project: true
-      #- name: Install Dependencies
-        #run: poetry install -v
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1.1.1 # see https://github.com/snok/install-poetry
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      - name: Install Dependencies
+        run: poetry install -v
+      - name: Check pip
+        run: poetry run pip --version
       #- name: Run Tox test suite
         #run: poetry run tox -c .toxrc -e "checks,coverage"
       #- name: Upload coverage data to coveralls.io

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        python: [3.7]
+        #os: [ubuntu-latest, macos-latest, windows-latest]
+        #python: [3.7, 3.8, 3.9]
     steps: 
       - name: Check out code
         uses: actions/checkout@v2
@@ -24,30 +26,32 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Upgrade pip
         run: pip install --upgrade pip
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@v1.1.1 # see https://github.com/snok/install-poetry
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      - name: Install Dependencies
-        run: poetry install -v
-      - name: Run Tox test suite
-        run: poetry run tox -c .toxrc -e "checks,coverage"
-      - name: Upload coverage data to coveralls.io
-        run: poetry run coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ runner.os }}-python${{ matrix.python }}
-          COVERALLS_PARALLEL: true
-  coveralls:
-    name: Indicate completion to coveralls.io
-    needs: build
-    runs-on: ubuntu-latest
-    container: python:3-slim
-    steps:
-    - name: Finished
-      run: |
-         pip3 install --upgrade coveralls
-         coveralls --service=github --finish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check pip
+        run: pip --version
+      #- name: Install and configure Poetry
+        #uses: snok/install-poetry@v1.1.1 # see https://github.com/snok/install-poetry
+        #with:
+          #virtualenvs-create: true
+          #virtualenvs-in-project: true
+      #- name: Install Dependencies
+        #run: poetry install -v
+      #- name: Run Tox test suite
+        #run: poetry run tox -c .toxrc -e "checks,coverage"
+      #- name: Upload coverage data to coveralls.io
+        #run: poetry run coveralls --service=github
+        #env:
+          #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          #COVERALLS_FLAG_NAME: ${{ runner.os }}-python${{ matrix.python }}
+          #COVERALLS_PARALLEL: true
+  #coveralls:
+    #name: Indicate completion to coveralls.io
+    #needs: build
+    #runs-on: ubuntu-latest
+    #container: python:3-slim
+    #steps:
+    #- name: Finished
+      #run: |
+         #pip3 install --upgrade coveralls
+         #coveralls --service=github --finish
+      #env:
+        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -33,31 +33,28 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
-      - name: Install Dependencies
+      - name: Install dependencies
         run: poetry install -v
-      - name: Check pip
-        run: poetry run pip --version
-      - name: Upgrade pip
-        run: poetry run pip install --upgrade pip
-      - name: Check pip
-        run: poetry run pip --version
-      #- name: Run Tox test suite
-        #run: poetry run tox -c .toxrc -e "checks,coverage"
-      #- name: Upload coverage data to coveralls.io
-        #run: poetry run coveralls --service=github
-        #env:
-          #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          #COVERALLS_FLAG_NAME: ${{ runner.os }}-python${{ matrix.python }}
-          #COVERALLS_PARALLEL: true
-  #coveralls:
-    #name: Indicate completion to coveralls.io
-    #needs: build
-    #runs-on: ubuntu-latest
-    #container: python:3-slim
-    #steps:
-    #- name: Finished
-      #run: |
-         #pip3 install --upgrade coveralls
-         #coveralls --service=github --finish
-      #env:
-        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upgrade embedded tools within virtualenv
+        # Safety will alert on these even though they aren't technically dependencies
+        run: poetry run pip install --upgrade pip setuptools wheel
+      - name: Run Tox test suite
+        run: poetry run tox -c .toxrc -e "checks,coverage"
+      - name: Upload coverage data to coveralls.io
+        run: poetry run coveralls --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: ${{ runner.os }}-python${{ matrix.python }}
+          COVERALLS_PARALLEL: true
+  coveralls:
+    name: Indicate completion to coveralls.io
+    needs: build
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+    - name: Finished
+      run: |
+         pip3 install --upgrade coveralls
+         coveralls --service=github --finish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/run
+++ b/run
@@ -10,9 +10,9 @@ run_install() {
       exit 1
    fi
 
-   # Upgrade packages within the virtualenv, like pip
-   # See: https://github.com/python-poetry/poetry/issues/1651#issuecomment-746486601
-   poetry run virtualenv --upgrade-embed-wheels --quiet | sed 's/^SystemExit: None/Completed updating embedded wheels/'
+   # Upgrade embedded packages within the virtualenv
+   # Safety will alert on these even though they aren't technically dependencies
+   poetry run pip install --quiet --upgrade pip setuptools wheel
    if [ $? != 0 ]; then
       exit 1
    fi


### PR DESCRIPTION
It turns out that Safety will alert on vulnerabilities in embedded tools like pip, wheel, or setuptools, even though they aren't technically dependencies for the package.    In this case, the build was failing because of a problem with pip.   The best solution I found for the GitHub action was to upgrade these 3 packages explicitly, but there are [other recommended alternatives](https://github.com/python-poetry/poetry/issues/1651#issuecomment-746486601).   I played with this on master a few times before realizing it wasn't a straightforward fix, so the [real diff](https://github.com/pronovic/apologies/compare/b8f6c732f6285ecb9572299dadaecbe4840c85c6...8d6e239d9226706e97363b01197f8bf65a715e94) is against [b8f6c73](https://github.com/pronovic/apologies/commit/b8f6c732f6285ecb9572299dadaecbe4840c85c6).