### PR TITLE
Modernize usage of attrs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -77,6 +77,10 @@ disable=fixme,
         no-self-use,
         duplicate-code,
         consider-using-f-string,
+        not-an-iterable, # gets confused with lists on attrs classes; MyPy covers this
+        unsupported-membership-test, # gets confused with dicts on attrs classes; MyPy covers this
+        unsupported-assignment-operation, # gets confused with dicts on attrs classes; MyPy covers this
+        no-member, # gets confused with dicts on attrs classes; MyPy covers this
         unsubscriptable-object # bug in Pylint & Python 3.9 gives "Value 'Optional' is unsubscriptable"
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.1.36     unreleased
+
+	* Modernize usage of attrs library.
+
 Version 0.1.35     30 Apr 2022
 
 	* Adjust the pyproject.toml include directive to limit what goes into wheel.

--- a/src/apologies/engine.py
+++ b/src/apologies/engine.py
@@ -8,7 +8,7 @@ Game engine that coordinates character actions to play a game.
 import random
 from typing import Callable, Dict, List, Optional, Tuple
 
-import attr
+from attrs import define, field
 
 from .game import Card, Game, GameMode, Player, PlayerColor, PlayerView
 from .rules import Move, Rules
@@ -16,7 +16,7 @@ from .source import CharacterInputSource
 from .util import CircularQueue
 
 
-@attr.s
+@define(slots=False)
 class Character:
 
     """
@@ -27,8 +27,8 @@ class Character:
         source(CharacterInputSource): The character input source from which moves are taken
     """
 
-    name = attr.ib(type=str)
-    source = attr.ib(type=CharacterInputSource)
+    name: str
+    source: CharacterInputSource
 
     def choose_move(
         self, mode: GameMode, view: PlayerView, legal_moves: List[Move], evaluator: Callable[[PlayerView, Move], PlayerView]
@@ -48,7 +48,7 @@ class Character:
         return self.source.choose_move(mode, view, legal_moves, evaluator)
 
 
-@attr.s
+@define
 class Engine:
 
     """
@@ -72,18 +72,19 @@ class Engine:
         first(PlayerColor): The first player, chosen randomly by default
     """
 
-    mode = attr.ib(type=GameMode)
-    characters = attr.ib(type=List[Character])
-    first = attr.ib(type=PlayerColor)
-    _game = attr.ib(init=False, type=Game)
-    _queue = attr.ib(init=False, type=CircularQueue[PlayerColor])
-    _rules = attr.ib(init=False, type=Rules)
-    _map = attr.ib(init=False, type=Dict[PlayerColor, Character])
+    mode: GameMode
+    characters: List[Character]
+    first: PlayerColor = field()
+    _game: Game = field(init=False)
+    _queue: CircularQueue[PlayerColor] = field(init=False)
+    _rules: Rules = field(init=False)
+    _map: Dict[PlayerColor, Character] = field(init=False)
 
     @first.default
     def _default_first(self) -> PlayerColor:
         return random.choice(list(PlayerColor)[: len(self.characters)])
 
+    # noinspection PyUnresolvedReferences
     @_game.default
     def _default_game(self) -> Game:
         return Game(playercount=len(self.characters))
@@ -92,10 +93,12 @@ class Engine:
     def _default_queue(self) -> CircularQueue[PlayerColor]:
         return CircularQueue(list(PlayerColor)[: len(self.characters)], first=self.first)
 
+    # noinspection PyUnresolvedReferences
     @_rules.default
     def _default_rules(self) -> Rules:
         return Rules(self.mode)
 
+    # noinspection PyUnresolvedReferences
     @_map.default
     def _default_map(self) -> Dict[PlayerColor, Character]:
         index = 0

--- a/src/apologies/rules.py
+++ b/src/apologies/rules.py
@@ -9,7 +9,7 @@ import uuid
 from enum import Enum
 from typing import List, Optional
 
-import attr
+from attrs import define, field, frozen
 
 from .game import (
     ADULT_HAND,
@@ -38,7 +38,7 @@ class ActionType(Enum):
     MOVE_TO_POSITION = "Move to position"  # Move a pawn to a specific position on the board
 
 
-@attr.s
+@frozen
 class Action:
     """
     An action that can be taken as part of a move.
@@ -49,12 +49,12 @@ class Action:
         position(Position): Optionally, a position the pawn should move to
     """
 
-    actiontype = attr.ib(type=ActionType)
-    pawn = attr.ib(type=Pawn)
-    position = attr.ib(default=None, type=Optional[Position])
+    actiontype: ActionType
+    pawn: Pawn
+    position: Optional[Position] = None
 
 
-@attr.s
+@frozen
 class Move:
 
     """
@@ -73,18 +73,10 @@ class Move:
         id(str): Identifier for this move, which must be unique among all legal moves this move is grouped with
     """
 
-    card = attr.ib(type=Card)
-    actions = attr.ib(type=List[Action])
-    side_effects = attr.ib(type=List[Action])
-    id = attr.ib(type=str)
-
-    @id.default
-    def _default_id(self) -> str:
-        return uuid.uuid4().hex
-
-    @side_effects.default
-    def _default_side_effects(self) -> List[Action]:
-        return []
+    card: Card
+    actions: List[Action]
+    side_effects: List[Action] = field(factory=list)
+    id: str = field(factory=lambda: uuid.uuid4().hex)
 
 
 # noinspection PyMethodMayBeStatic
@@ -408,7 +400,7 @@ class BoardRules:
 
 
 # noinspection PyProtectedMember
-@attr.s
+@define(slots=False)
 class Rules:
 
     """
@@ -418,12 +410,8 @@ class Rules:
         mode(GameMode): The game mode
     """
 
-    mode = attr.ib(type=GameMode)
-    _board_rules = attr.ib(init=False, type=BoardRules)
-
-    @_board_rules.default
-    def _default_board_rules(self) -> BoardRules:
-        return BoardRules()
+    mode: GameMode
+    _board_rules: BoardRules = field(init=False, factory=BoardRules)
 
     # noinspection PyMethodMayBeStatic
     def draw_again(self, card: Card) -> bool:

--- a/src/apologies/rules.py
+++ b/src/apologies/rules.py
@@ -51,7 +51,7 @@ class Action:
 
     actiontype = attr.ib(type=ActionType)
     pawn = attr.ib(type=Pawn)
-    position = attr.ib(default=None, type=Position)
+    position = attr.ib(default=None, type=Optional[Position])
 
 
 @attr.s
@@ -396,7 +396,7 @@ class BoardRules:
                 if action.actiontype == ActionType.MOVE_TO_POSITION:  # look at any move to a position on the board
                     for color in [color for color in PlayerColor if color != action.pawn.color]:  # any color other than the pawn's
                         for (start, end) in SLIDE[color]:  # look at all slides with this color
-                            if action.position.square == start:  # if the pawn landed on the start of the slide
+                            if action.position and action.position.square == start:  # if the pawn landed on the start of the slide
                                 action.position.move_to_square(end)  # move the pawn to the end of the slide
                                 for square in range(start + 1, end + 1):  # and then bump any pawns that were already on the slide
                                     # Note: in this one case, a pawn can bump another pawn of the same color
@@ -485,7 +485,7 @@ class Rules:
             if action.actiontype == ActionType.MOVE_TO_START:
                 pawn.position.move_to_start()
                 log += "%s->start, " % pawn.name
-            elif action.actiontype == ActionType.MOVE_TO_POSITION:
+            elif action.actiontype == ActionType.MOVE_TO_POSITION and action.position:
                 pawn.position.move_to_position(action.position)
                 log += "%s, " % pawn
         log += "]"
@@ -515,7 +515,7 @@ class Rules:
             if pawn:  # if the pawn isn't valid, just ignore it
                 if action.actiontype == ActionType.MOVE_TO_START:
                     pawn.position.move_to_start()
-                elif action.actiontype == ActionType.MOVE_TO_POSITION:
+                elif action.actiontype == ActionType.MOVE_TO_POSITION and action.position:
                     pawn.position.move_to_position(action.position)
         return result
 

--- a/src/apologies/simulation.py
+++ b/src/apologies/simulation.py
@@ -12,8 +12,8 @@ import statistics
 from itertools import combinations_with_replacement
 from typing import Dict, List, Optional, Sequence
 
-import attr
 import pendulum
+from attrs import frozen
 from pendulum import DateTime  # type: ignore
 
 from .engine import Character, Engine
@@ -55,29 +55,29 @@ def _median(data: Sequence[float]) -> Optional[float]:
     return round(statistics.median(data), 2) if data else None
 
 
-@attr.s
+@frozen
 class _Result:
 
     """Result of a single game within a scenario."""
 
-    start = attr.ib(type=DateTime)
-    stop = attr.ib(type=DateTime)
-    character = attr.ib(type=Character)
-    player = attr.ib(type=Player)
+    start: DateTime
+    stop: DateTime
+    character: Character
+    player: Player
 
 
-@attr.s
+@frozen
 class _Statistics:
 
     """Scenario statistics for a source."""
 
-    source = attr.ib(type=Optional[str])
-    median_turns = attr.ib(type=Optional[float])
-    mean_turns = attr.ib(type=Optional[float])
-    median_duration = attr.ib(type=Optional[float])
-    mean_duration = attr.ib(type=Optional[float])
-    wins = attr.ib(type=int)
-    win_percent = attr.ib(type=float)
+    source: Optional[str]
+    median_turns: Optional[float]
+    mean_turns: Optional[float]
+    median_duration: Optional[float]
+    mean_duration: Optional[float]
+    wins: int
+    win_percent: float
 
     @staticmethod
     def for_results(name: Optional[str], results: List[_Result]) -> _Statistics:
@@ -93,17 +93,17 @@ class _Statistics:
         return _Statistics(name, median_turns, mean_turns, median_duration, mean_duration, wins, win_percent)
 
 
-@attr.s
+@frozen
 class _Analysis:
     """Groups together information analyzed for a scenario."""
 
-    scenario = attr.ib(type=str)
-    mode = attr.ib(type=str)
-    iterations = attr.ib(type=int)
-    players = attr.ib(type=int)
-    playernames = attr.ib(type=List[str])
-    overall_stats = attr.ib(type=_Statistics)
-    source_stats = attr.ib(type=Dict[str, _Statistics])
+    scenario: str
+    mode: str
+    iterations: int
+    players: int
+    playernames: List[str]
+    overall_stats: _Statistics
+    source_stats: Dict[str, _Statistics]
 
 
 def _analyze_scenario(

--- a/src/apologies/source.py
+++ b/src/apologies/source.py
@@ -10,8 +10,6 @@ from abc import ABC, abstractmethod
 from pydoc import locate
 from typing import Callable, List, Tuple
 
-import attr
-
 from .game import GameMode, PlayerView
 from .reward import RewardCalculatorV1
 from .rules import Move
@@ -63,7 +61,6 @@ class CharacterInputSource(ABC):
         """
 
 
-@attr.s
 class NoOpInputSource(CharacterInputSource):
 
     """
@@ -82,7 +79,6 @@ class NoOpInputSource(CharacterInputSource):
         raise NotImplementedError
 
 
-@attr.s
 class RandomInputSource(CharacterInputSource):
 
     """
@@ -97,7 +93,6 @@ class RandomInputSource(CharacterInputSource):
 
 
 # noinspection PyMethodMayBeStatic
-@attr.s
 class RewardInputSource(CharacterInputSource):
 
     """

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -552,10 +552,10 @@ class TestEngine:
     @staticmethod
     def _create_engine(mode: GameMode = GameMode.STANDARD) -> Engine:
         character1 = Character("character1", Mock())
-        character1.construct_move = MagicMock()  # type: ignore
+        character1.choose_move = MagicMock()  # type: ignore
 
         character2 = Character("character2", Mock())
-        character1.construct_move = MagicMock()  # type: ignore
+        character1.choose_move = MagicMock()  # type: ignore
 
         first = PlayerColor.RED
         engine = Engine(mode, [character1, character2], first=first)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
-# pylint: disable=redefined-outer-name,protected-access,broad-except,too-many-public-methods
+# pylint: disable=redefined-outer-name,protected-access,broad-except,too-many-public-methods,assigning-non-slot
 # Unit tests for engine.py
 
 from unittest.mock import MagicMock, Mock, PropertyMock, call, patch

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
-# pylint: disable=no-self-use,protected-access,too-many-locals,too-many-statements
+# pylint: disable=no-self-use,protected-access,too-many-locals,too-many-statements,assigning-non-slot
 
 from unittest.mock import MagicMock, call, patch
 
@@ -31,6 +31,13 @@ class TestMove:
         assert move.card is card
         assert move.actions == actions
         assert move.id == "uuid"
+
+    def test_constructor_uuid_unique(self):
+        card = Card(3, CardType.CARD_12)
+        actions = [Action(ActionType.MOVE_TO_START, pawn=Pawn(PlayerColor.BLUE, 1, "whatever"))]
+        move1 = Move(card, actions)
+        move2 = Move(card, actions)
+        assert move1.id != move2.id  # just make sure we get a unique UUID each time in the default case
 
     def test_constructor_explicit(self):
         card = Card(3, CardType.CARD_12)


### PR DESCRIPTION
I first established patterns to use with attrs in early 2020 using v19.3.0.  Since then, they've published a new, simplified interface and have changed their recommended design patterns.  This PR modernizes the code to follow the new recommendations when using v21.4.0.  (See the [changelog](https://www.attrs.org/en/stable/changelog.html).)

---

This is turning out to be harder than I expected.  I've converted other code without too many problems, but in here something gets bunged up at the intersection of attrs and cattrs for JSON serialization and deserialization.  

I've managed to successfully convert all modules except `game.py` by following an incremental approach - convert one class at a time, address warnings and unit test failures, etc.  In the case of `game.py`, I've had no success.   If I convert even one class in that module, I immediately get around 40 unit test failures tied to cattrs and serialization.   The errors make very little sense. (Like, WTF would prevent cattrs from finding a converter for `int` or `bool`?) 

I don't want to have the code in a partially converted state with some classes using the old standard and some using the new standard.  It seems better to either convert entirely, or stay on the old standard entirely.  So, I am leaving this open as a draft until I can figure out a way forward.