### PR TITLE
Fix matrix build in GitHub Actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,12 +10,15 @@ on:
     - cron: '05 17 15 * *'  # 15th of the month at 5:05pm UTC
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python: ["3.7", "3.8", "3.9", "3.10" ]
+    runs-on: ${{ matrix.os }}
     env:
+      # Run builds using a specific version of Poetry, to avoid surprises
+      POETRY_VERSION: "1.2.0"
+      # Ensure that Poetry never tries to unlock a keyring, which will either fail or hang
       # See: https://github.com/python-poetry/poetry/issues/2692#issuecomment-1235683370
       PYTHON_KEYRING_BACKEND: "keyring.backends.null.Keyring"
     steps: 
@@ -25,9 +28,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - name: Platform information
+        run: |
+          python utils/showplatform.py
       - name: Install Poetry
         uses: snok/install-poetry@v1.2.1 # see https://github.com/snok/install-poetry
         with:
+          version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Install Poetry plugins

--- a/utils/showplatform.py
+++ b/utils/showplatform.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# Display information about the current platform
+
+import sys
+import platform
+
+fields = [ '   %s: %s' % i for i in zip(['system','node','release','version','machine','processor'], platform.uname()) if i[1] ]
+print("Python %s" % sys.version)
+print("Platform\n%s" % "\n".join(fields))

--- a/utils/showplatform.py
+++ b/utils/showplatform.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # Display information about the current platform
 
-import sys
 import platform
+import sys
 
-fields = [ '   %s: %s' % i for i in zip(['system','node','release','version','machine','processor'], platform.uname()) if i[1] ]
+fields = ["   %s: %s" % i for i in zip(["system", "node", "release", "version", "machine", "processor"], platform.uname()) if i[1]]
 print("Python %s" % sys.version)
 print("Platform\n%s" % "\n".join(fields))


### PR DESCRIPTION
Somewhere along the line, I lost proper configuration for the matrix build operating system in the GitHub Actions workflow.  Every build was running on Ubuntu, rather than on a combination of Ubuntu, MacOS, and Windows.