### PR TITLE
Migrate to v4 of gha-shared-workflows

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   linux-build-and-test:
     name: "Linux"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v3
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v4
     secrets: inherit
     with:
       matrix-os-version: "[ 'ubuntu-latest' ]"
@@ -25,7 +25,7 @@ jobs:
       enable-coveralls: true  # only report to coveralls.io for tests that run on Linux
   macos-build-and-test:
     name: "MacOS"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v3
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v4
     secrets: inherit
     with:
       matrix-os-version: "[ 'macos-latest' ]"
@@ -34,7 +34,7 @@ jobs:
       enable-coveralls: false 
   windows-build-and-test:
     name: "Windows"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v3
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v4
     secrets: inherit
     with:
       matrix-os-version: "[ 'windows-latest' ]"
@@ -44,7 +44,7 @@ jobs:
   release:
     name: "Release"
     if: github.ref_type == 'tag'
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v3
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v4
     needs: [ linux-build-and-test, macos-build-and-test, windows-build-and-test ]
     secrets: inherit
     with:


### PR DESCRIPTION
v4 of the shared workflows uses pronovic/setup-poetry@v2, which migrates to the pipx install method under the covers.  The changes are mostly transparent.