### PR TITLE
Migrate to shared workflows v7 for PyPI trusted publishing

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   linux-build-and-test:
     name: "Linux"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'ubuntu-latest' ]"
@@ -24,7 +24,7 @@ jobs:
       enable-coveralls: true  # only report to coveralls.io for tests that run on Linux
   macos-build-and-test:
     name: "MacOS"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'macos-latest' ]"
@@ -32,7 +32,7 @@ jobs:
       enable-coveralls: false 
   windows-build-and-test:
     name: "Windows"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'windows-latest' ]"
@@ -41,9 +41,10 @@ jobs:
   release:
     name: "Release"
     if: github.ref_type == 'tag'
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v7
     needs: [ linux-build-and-test, macos-build-and-test, windows-build-and-test ]
     secrets: inherit
     with:
-      python-version: "3.10"   # run release with oldest supported Python version
+      project-name: "apologies"
+      python-version: "3.10"    # run release with oldest supported Python version
       publish-pypi: true

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.1.52     unreleased
+
+	* Migrate to shared workflows v7 for PyPI trusted publishing.
+
 Version 0.1.51     17 Dec 2024
 
 	* Make security improvements in GHA worksflows.


### PR DESCRIPTION
The only good way to test changes to GitHub workflows is in an actual PR.  When the changes involve the publishing process, you actually have to publish to test.  Since apologies is non-production code, it's best of my repositories to use for this work.