### PR TITLE
Remove restriction on branches for PR build

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,8 +8,6 @@ on:
     tags:
       - "v*"
   pull_request:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/Changelog
+++ b/Changelog
@@ -3,8 +3,8 @@ Version 0.2.2     unreleased
 	* Add information about the Python runtime to suite output.
 	* Upgrade to poetry-dynamic-versioning v1.5.2 for minor fixes.
 	* Add .python-version in preferred order to support pyenv.
-	* Pull in latest version of run-script-framework.
 	* Add Sphinx configuration path to .readthedocs.yml.
+	* Adjust GHA build process to allow builds for stacked PRs.
 	* Update the jinja2 transitive dependency to address CVE-2025-27516.
 	* Update the requests transitive dependency to address CVE-2024-47081.
 	* Update the urllib3 transitive dependency to address CVE-2025-50181.


### PR DESCRIPTION
I want to be able to stack pull requests, and the current GitHub Actions workflow prevents builds from happening on stacked PRs.