### PR TITLE
Remove importlib-metadata dependency in favor of standard library

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -10,7 +10,7 @@ Version 0.2.2     unreleased
 	* Update the MyPy configuration so we're using latest rules.
 	* Replace black, isort, and pylint with the Ruff formatter and linter.
 	* Address Ruff linter warnings and modernize the code to 2025 standards.
-	* Remove importlib_metadata dependency in favor of standard library.
+	* Remove importlib-metadata dependency in favor of standard library.
 	* Update all dependencies and outdated constraints.
 
 Version 0.2.1     08 Jan 2025

--- a/Changelog
+++ b/Changelog
@@ -10,6 +10,7 @@ Version 0.2.2     unreleased
 	* Update the MyPy configuration so we're using latest rules.
 	* Replace black, isort, and pylint with the Ruff formatter and linter.
 	* Address Ruff linter warnings and modernize the code to 2025 standards.
+	* Remove importlib_metadata dependency in favor of standard library.
 	* Update all dependencies and outdated constraints.
 
 Version 0.2.1     08 Jan 2025

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,7 @@
 
 import os
 import sys
-from pathlib import Path
-from importlib_metadata import metadata
+from importlib.metadata import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/poetry.lock
+++ b/poetry.lock
@@ -456,31 +456,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-description = "Read metadata from Python packages"
-optional = true
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"docs\""
-files = [
-    {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
-    {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib_resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
@@ -1229,31 +1204,10 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
-[[package]]
-name = "zipp"
-version = "3.23.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = true
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"docs\""
-files = [
-    {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
-    {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [extras]
-docs = ["importlib-metadata", "sphinx", "sphinx-autoapi"]
+docs = ["sphinx", "sphinx-autoapi"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "92dda2877c4c1986dafa6e9730dd2fdd3318478ffc84ade49e7a3366db8c6f96"
+content-hash = "9b8f9a71eb9d853d791495c2329db80ea15c3020e092e275a2c973399d11b84e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ repository = "https://github.com/pronovic/apologies"
 
 [project.optional-dependencies]
 docs = [
-   "importlib-metadata (>=8.5.0,<9.0.0)",
    "sphinx (>=8.1.3,<9.0.0)",
    "sphinx-autoapi (>=3.3.3,<4.0.0)",
 ]


### PR DESCRIPTION
Based on [the docs](https://docs.python.org/3/library/importlib.metadata.html), `importlib.metadata` is "no longer provisional" as of Python 3.10. Looking back at the commit history, I added this dependency back in late 2022, when I was supporting Python 3.8.  I don't need it any more, and I can rely on the standard library instead.