### PR TITLE
Fix pytest-testdox output in GHA Windows runner

### DIFF
--- a/.run/commands/pytest.sh
+++ b/.run/commands/pytest.sh
@@ -35,19 +35,18 @@ command_pytest() {
 
    color=""
    if [ "$GITHUB_ACTIONS" == "true" ] && [ "$RUNNER_OS" == "Windows" ]; then
-      export PYTHONUTF8=1 # otherwise unicode like ✓ gets displayed as \u2713 instead
       color="--color no"  # color messes up the terminal on Windows in GHA
    fi
 
    if [ $coverage == "yes" ]; then
-      run_command uvrun pytest --cov=. --testdox --force-testdox $color $tests
+      PYTHONUTF8=1 run_command uvrun pytest --cov=. --testdox --force-testdox $color $tests
       run_command uvrun coverage lcov -o .coverage.lcov
       if [ $html == "yes" ]; then
          run_command uvrun coverage html -d .htmlcov
          run_command openfile .htmlcov/index.html
       fi
    else
-      run_command uvrun pytest --testdox --force-testdox $color $tests
+      PYTHONUTF8=1 run_command uvrun pytest --testdox --force-testdox $color $tests
    fi
 }
 

--- a/.run/commands/pytest.sh
+++ b/.run/commands/pytest.sh
@@ -35,6 +35,7 @@ command_pytest() {
 
    color=""
    if [ "$GITHUB_ACTIONS" == "true" ] && [ "$RUNNER_OS" == "Windows" ]; then
+      export PYTHONUTF8=1 # otherwise unicode like ✓ gets displayed as \u2713 instead
       color="--color no"  # color messes up the terminal on Windows in GHA
    fi
 

--- a/.run/commands/pytest.sh
+++ b/.run/commands/pytest.sh
@@ -33,20 +33,15 @@ command_pytest() {
 
    shift $((OPTIND -1))  # pop off the options consumed by getopts
 
-   color=""
-   if [ "$GITHUB_ACTIONS" == "true" ] && [ "$RUNNER_OS" == "Windows" ]; then
-      color="--color no"  # color messes up the terminal on Windows in GHA
-   fi
-
    if [ $coverage == "yes" ]; then
-      PYTHONUTF8=1 run_command uvrun pytest --cov=. --testdox --force-testdox $color $tests
+      PYTHONUTF8=1 run_command uvrun pytest --cov=. --testdox --force-testdox $tests
       run_command uvrun coverage lcov -o .coverage.lcov
       if [ $html == "yes" ]; then
          run_command uvrun coverage html -d .htmlcov
          run_command openfile .htmlcov/index.html
       fi
    else
-      PYTHONUTF8=1 run_command uvrun pytest --testdox --force-testdox $color $tests
+      PYTHONUTF8=1 run_command uvrun pytest --testdox --force-testdox $tests
    fi
 }
 

--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Version 0.4.3     unreleased
 	* Fix Sphinx autoapi to generate docs for source, not tests.
 	* Add support for Visual Studio Code as an IDE.
 	* Use pytest-cov for test coverage, for more consistency.
+	* Fix pytest-testdox output in GHA Windows runner.
 
 Version 0.4.2     24 Sep 2025
 


### PR DESCRIPTION
This has been a problem for years, but I've only just now found a solution for it.  In GitHub Actions, the Windows runners don't render the output from pytest-testdox correctly.

When running on Linux and MacOS (and even my local Windows Terminal running Git Bash), this is the way the test results are displayed:

```
Circular Queue
 ✓ constructor empty
 ✓ constructor single
```

The GitHub Actions runner for Windows sees this instead, with the `✓` replaced by `\u2713`:

```
Circular Queue
 \u2713 constructor empty
 \u2713 constructor single
```

My assumption has always been that there was something wrong/different with the way the terminal was set up on GitHub Actions, but it wasn't clear how to deal with it.  Now that I've dug in further, it turns out that the fix is to export  `PYTHONUTF8=1` from [PEP 540](https://peps.python.org/pep-0540/).  As a nice side effect, this same change also fixes problems displaying color in the test output, which allows me to get rid of an additional special case in `.run/commands/pytest.sh`.

**Note:** I ran across this solution in [flet issue #5272](https://github.com/flet-dev/flet/issues/5272), where setting this environment variable fixed a similar-sounding problem.  