### PR TITLE
Test latest shared GitHub workflows

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,7 +7,7 @@ Version 0.4.3     unreleased
 	* Add support for Visual Studio Code as an IDE.
 	* Use pytest-cov for test coverage, for more consistency.
 	* Fix pytest-testdox output in GHA Windows runner.
-	* TEMPORARY: migrate to latest actions
+	* TEMPORARY: another change
 
 Version 0.4.2     24 Sep 2025
 

--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Version 0.4.3     unreleased
 	* Add support for Visual Studio Code as an IDE.
 	* Use pytest-cov for test coverage, for more consistency.
 	* Fix pytest-testdox output in GHA Windows runner.
+	* TEMPORARY: migrate to latest actions
 
 Version 0.4.2     24 Sep 2025
 


### PR DESCRIPTION
This tests the latest version of gha-shared-workflows, which upgrades to newer versions of some shared actions to get Node 24.  I'll close it once I've proved that things seem to work ok.